### PR TITLE
Update 02-hypr-pkgs.sh   rofi-wayland package name now just rofi 

### DIFF
--- a/install-scripts/02-hypr-pkgs.sh
+++ b/install-scripts/02-hypr-pkgs.sh
@@ -43,7 +43,7 @@ hypr_package=(
   qt5ct
   qt6ct
   qt6-svg-devel
-  rofi-wayland
+  rofi
   slurp
   swappy
   SwayNotificationCenter


### PR DESCRIPTION
Rofi-wayland has changed to just 'rofi'

# Pull Request

## Description
 
   rofi-wayland package name now just rofi 

## Type of change


- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/OpenSuse-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/OpenSuse-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.

